### PR TITLE
marks module as complete

### DIFF
--- a/src/Module/components/ModuleDefault.vue
+++ b/src/Module/components/ModuleDefault.vue
@@ -407,7 +407,7 @@ export default defineComponent({
       summerHours: ''
     };
 
-    const { adkData } = getModAdk(
+    const { adkData, adkIndex } = getModAdk(
       props,
       ctx.emit,
       'autoapply',
@@ -460,6 +460,12 @@ export default defineComponent({
       return new Promise((resolve, reject) => {
         studentDoc.value.update();
         resolve(true);
+
+        // Tell the user they've auto-applied and let them continue to the next section.
+        adkData.value.update(() => ({
+          isComplete: true,
+          adkIndex: adkIndex
+        }));
       });
     }
 

--- a/src/Module/types.ts
+++ b/src/Module/types.ts
@@ -2,7 +2,7 @@ export default interface MongoDoc {
   data: {
     adks: Record<string, any>[];
   };
-  update: () => Promise<any>;
+  update: (shouldMarkAsComplete?:any) => Promise<any>;
   changeStream: any;
 }
 


### PR DESCRIPTION
I have not been able to test this module, so I'm just taking my best guess as to how we want to evaluate when users have completed it. In this case, I assume that calling `populate()` will mark it as complete. This happens when the user hits the save button.

# TODO
- [ ] test module (module is incomplete at the time of this PR)
- [ ] bump up npm package version